### PR TITLE
Fixes Bug Where AltiumWire Was Rendered Incorrectly

### DIFF
--- a/altium_sch_document.js
+++ b/altium_sch_document.js
@@ -313,9 +313,9 @@ class AltiumLine extends AltiumObject
 		super(record);
 		
 		this.x1 = Number.parseInt(this.attributes.location_x, 10);
-		this.y1 = Number.parseInt(this.attributes.corner_x, 10);
-		this.x2 = Number.parseInt(this.attributes.corner_y, 10);
-		this.y2 = Number.parseInt(this.attributes.location_y, 10);
+		this.x2 = Number.parseInt(this.attributes.corner_x, 10);
+		this.y1 = Number.parseInt(this.attributes.location_y, 10);
+		this.y2 = Number.parseInt(this.attributes.corner_y, 10);
 		this.width = Number.parseInt(this.attributes.linewidth ?? "1", 10);
 		this.colour = Number.parseInt(this.attributes.color ?? "0", 10);
 	}


### PR DESCRIPTION
Before fix:
<img width="383" alt="image" src="https://user-images.githubusercontent.com/118142981/203869836-8af7d957-2e85-4103-9bf9-9840cacc15e5.png">
